### PR TITLE
Add adjust htaccess

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(
     python_requires='>=3.6.0',
     include_package_data=True,
     license="MIT",
-    extras_require={'test': ['pytest', 'pycodestyle']},
+    extras_require={'test': ['pytest', 'pycodestyle', 'parse']},
 )

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     python_requires='>=3.6.0',
     include_package_data=True,
     license="MIT",
-    extras_require={'test': ['pytest', 'pycodestyle', 'parse']},
+    extras_require={'test': ['pytest', 'pycodestyle']},
+    setup_requires=['wheel'],
     install_requires=['wheel', 'parse']
 )

--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ setup(
     include_package_data=True,
     license="MIT",
     extras_require={'test': ['pytest', 'pycodestyle', 'parse']},
+    install_requires=['wheel', 'parse']
 )

--- a/src/nfs4_share/acl.py
+++ b/src/nfs4_share/acl.py
@@ -43,7 +43,7 @@ class AccessControlList:
         return new_acl
 
     def __add__(self, other):
-        new_acl = AccessControlList(self.entries + other.entries)
+        new_acl = AccessControlList(set(self.entries + other.entries))
         return new_acl
 
     @classmethod
@@ -135,6 +135,9 @@ class AccessControlEntity:
             if perm not in other.permissions:
                 return False
         return True
+
+    def __hash__(self):
+        return hash(str(self))
 
     @property
     def permissions(self):

--- a/src/nfs4_share/acl.py
+++ b/src/nfs4_share/acl.py
@@ -35,6 +35,9 @@ class AccessControlList:
     def __iter__(self):
         return iter(self.entries)
 
+    def __lt__(self, other):
+        return str(self) > str(other)
+
     def __sub__(self, other):  # self - other
         first_index, last_index = find_sub_list(other.entries, self.entries)
         if first_index is None:  # No sublist was found

--- a/src/nfs4_share/acl.py
+++ b/src/nfs4_share/acl.py
@@ -174,7 +174,8 @@ class AccessControlEntity:
     @staticmethod
     def translate_special_principals(principal, filename, flags):
         """
-        Translates a special principal to the actual user / group name. NFS4 share domain is taken from /etc/idmapd.conf and falls back on `dnsdomainname`.
+        Translates a special principal to the actual user / group name. NFS4 share domain is taken from
+        /etc/idmapd.conf and falls back on `dnsdomainname`.
         Returns identity, domain and flags"""
         domain = get_nfs4_domain()
         stat_info = os.stat(filename)
@@ -194,7 +195,8 @@ class AccessControlEntity:
 
 
 def get_nfs4_domain():
-    domain = subprocess.run(['egrep', '-s', '^Domain', '/etc/idmapd.conf'], stdout=subprocess.PIPE).stdout.decode('utf-8').rstrip()
+    domain = subprocess.run(['egrep', '-s', '^Domain', '/etc/idmapd.conf'],
+                            stdout=subprocess.PIPE).stdout.decode('utf-8').rstrip()
     try:
         domain = re.search('[a-z\\.\\-]+$', domain).group(0)
     except AttributeError:

--- a/src/nfs4_share/acl.py
+++ b/src/nfs4_share/acl.py
@@ -142,6 +142,9 @@ class AccessControlEntity:
     def __hash__(self):
         return hash(str(self))
 
+    def __lt__(self, other):
+        return str(self) > str(other)
+
     @property
     def permissions(self):
         return self._permissions

--- a/src/nfs4_share/cli.py
+++ b/src/nfs4_share/cli.py
@@ -59,18 +59,22 @@ def _cli_argument_parser():
     create_parser.add_argument('-d', '--domain', required=False, dest='domain', default=default_domain,
                                help="general domain used to build the user and group principles (NFSv4 ACLs) "
                                     "if not provided it is looked up using command dnsdomainname")
-    create_parser.add_argument('-saa', '--service-application-accounts ', action='extend', nargs="*", required=False, dest='service_application_accounts',
-                               help="service application accounts under which the services (e.g. HTTP) are running that should have access to the share (NFSv4 ACLs)")
+    create_parser.add_argument('-saa', '--service-application-accounts ', action='extend', nargs="*", required=False,
+                               dest='service_application_accounts',
+                               help="service application accounts under which the services (e.g. HTTP) are running "
+                                    "that should have access to the share (NFSv4 ACLs)")
     create_parser.add_argument('-uad', '--user-apache-directive', required=False,
                                default="Require ldap-user {}",
                                help="This directive template specifies an user who is allowed access "
                                     "to a share via htaccess. "
                                     "Default: 'Require ldap-user {}' where {} is replaced by the user")
     create_parser.add_argument('-gad', '--group-apache-directive', required=False,
-                               default="Require ldap-group cn={},cn=groups,cn=accounts,dc=researchidt,dc=prinsesmaximacentrum,dc=nl",
+                               default="Require ldap-group cn={},cn=groups,cn=accounts,dc=researchidt,"
+                                       "dc=prinsesmaximacentrum,dc=nl",
                                help="This directive template specifies an group whose members are allowed access "
                                     "to a share via htaccess. "
-                                    "Default: 'Require ldap-group cn={},cn=groups,cn=accounts,dc=researchidt,dc=prinsesmaximacentrum,dc=nl' where {} is replaced by the group")
+                                    "Default: 'Require ldap-group cn={},cn=groups,cn=accounts,dc=researchidt,"
+                                    "dc=prinsesmaximacentrum,dc=nl' where {} is replaced by the group")
 
     # Sub-parser for removing a share
     delete_parser = subparsers.add_parser('delete', aliases=['rm', 'remove', 'del'],

--- a/src/nfs4_share/cli.py
+++ b/src/nfs4_share/cli.py
@@ -106,8 +106,22 @@ def _cli_argument_parser():
     add_parser.add_argument('-d', '--domain', required=False, dest='domain', default=default_domain,
                             help="general domain used to build the user and group principles (NFSv4 ACLs)"
                                  "if not provided it is looked up using command dnsdomainname")
-    add_parser.add_argument('-saa', '--service-application-accounts ', action='extend', nargs="*", required=False, dest='service_application_accounts',
-                            help="service application accounts under which the services (e.g. HTTP) are running that should have access to the share (NFSv4 ACLs)")
+    add_parser.add_argument('-saa', '--service-application-accounts ', action='extend', nargs="*", required=False,
+                            dest='service_application_accounts',
+                            help="service application accounts under which the services (e.g. HTTP) are running that "
+                                 "should have access to the share (NFSv4 ACLs)")
+    add_parser.add_argument('-uad', '--user-apache-directive', required=False,
+                            default="Require ldap-user {}",
+                            help="This directive template specifies an user who is allowed access "
+                                 "to a share via htaccess. "
+                                 "Default: 'Require ldap-user {}' where {} is replaced by the user")
+    add_parser.add_argument('-gad', '--group-apache-directive', required=False,
+                            default="Require ldap-group cn={},cn=groups,cn=accounts,dc=researchidt,"
+                                    "dc=prinsesmaximacentrum,dc=nl",
+                            help="This directive template specifies an group whose members are allowed access "
+                                 "to a share via htaccess. "
+                                 "Default: 'Require ldap-group cn={},cn=groups,cn=accounts,dc=researchidt,"
+                                 "dc=prinsesmaximacentrum,dc=nl' where {} is replaced by the group")
     return parser
 
 

--- a/src/nfs4_share/htaccess.py
+++ b/src/nfs4_share/htaccess.py
@@ -1,6 +1,9 @@
 
 import os
 import logging
+import warnings
+import parse
+from share import Share
 
 
 def create_at(share, users, user_directive_template, groups, group_directive_template, filename='.htaccess.files.bioinf'):
@@ -19,6 +22,48 @@ def create_at(share, users, user_directive_template, groups, group_directive_tem
             f.write("%s\n" % line)
     share.permissions.set(htaccess_file_path)
     logging.debug("Generated and placed htaccess file at %s: %s" % (htaccess_file_path, htaccess))
+
+
+def append_at(share: Share, users: list, user_directive_template: str, groups: list, group_directive_template: str,
+              filename: str = '.htaccess.files.bioinf'):
+    """
+    Creates a new .htaccess file containing the existing users/groups plus the new ones.
+    WARNING: the directive_template has to be the same as the one used during creation otherwise you might lose
+    permissions for some users/groups
+    """
+    # Try to extract existing htaccess users and groups
+    try:
+        # Create path to htaccess file
+        htaccess_file_path = os.path.join(share.directory, filename)
+        # Try to open it
+        with open(htaccess_file_path, 'r') as htaccess_file:
+            htaccess_lines = htaccess_file.readlines()
+        # Remove unwanted characters
+        htaccess_lines = [line.strip() for line in htaccess_lines]
+        # extract users and groups
+        users += extract_targets(htaccess_lines, user_directive_template)
+        groups += extract_targets(htaccess_lines, group_directive_template)
+    except FileNotFoundError:
+        warnings.warn(f"No file found called {filename} to append new users/groups to, will create it instead.")
+
+    # Recreate htaccess file
+    # list(set()) just to make sure the list is unique to avoid duplications
+    create_at(share, list(set(users)), user_directive_template, list(set(groups)), group_directive_template, filename)
+
+
+def extract_targets(lines: list, format_string: str):
+    """ Function to extract values used during formatting of a string
+
+    :param lines: List of strings to search in
+    :param format_string: Format string used in the past to parse values into a string
+    :return: list of values found with the parse function
+    """
+    found_targets = []
+    for line in lines:
+        parsed = parse.parse(format_string, line)
+        if parsed is not None:
+            found_targets += list(parsed)
+    return found_targets
 
 
 def remove_from(share, filename='.htaccess.files.bioinf', absent_ok=False):

--- a/src/nfs4_share/htaccess.py
+++ b/src/nfs4_share/htaccess.py
@@ -3,7 +3,7 @@ import os
 import logging
 import warnings
 import parse
-from share import Share
+from .share import Share
 
 
 def create_at(share, users, user_directive_template, groups, group_directive_template, filename='.htaccess.files.bioinf'):

--- a/src/nfs4_share/htaccess.py
+++ b/src/nfs4_share/htaccess.py
@@ -6,7 +6,8 @@ import parse
 from .share import Share
 
 
-def create_at(share, users, user_directive_template, groups, group_directive_template, filename='.htaccess.files.bioinf'):
+def create_at(share, users, user_directive_template, groups, group_directive_template,
+              filename='.htaccess.files.bioinf'):
     """
     Creates an .htaccess (or alternative filename) to give access for an apache server to provide access to a share
     """

--- a/src/nfs4_share/manage.py
+++ b/src/nfs4_share/manage.py
@@ -59,7 +59,7 @@ def create(share_directory, domain, user_apache_directive="{}", group_apache_dir
     return share
 
 
-def add(share_directory, user_apache_directive, group_apache_directive, domain=None, items=None, users=None,
+def add(share_directory, user_apache_directive="{}", group_apache_directive="{}", domain=None, items=None, users=None,
         groups=None, managing_users=None, managing_groups=None, lock=False, service_application_accounts=None):
     """
         Updates a share. The directory representing the share should exist.
@@ -187,14 +187,14 @@ def generate_permissions(users, groups, managing_users, managing_groups, domain)
                                        flags='',
                                        identity=user,
                                        domain=domain,
-                                       permissions='rxwaDdtTNcCo')
+                                       permissions='rwxaDdtTNcCo')
         entries.append(user_ace)
     for group in managing_groups:
         group_ace = AccessControlEntity(entry_type='A',
                                         flags='g',
                                         identity=group,
                                         domain=domain,
-                                        permissions='rxwaDdtTNcCo')
+                                        permissions='rwxaDdtTNcCo')
         entries.append(group_ace)
 
     acl = AccessControlList(entries)

--- a/src/nfs4_share/manage.py
+++ b/src/nfs4_share/manage.py
@@ -46,7 +46,8 @@ def create(share_directory, domain, user_apache_directive="{}", group_apache_dir
                                              groups=groups,
                                              managing_users=managing_users,
                                              managing_groups=managing_groups,
-                                             domain=domain)
+                                             domain=domain,
+                                             manage_permissions=share.MANAGE_PERMISSION_UNLOCK)
     share.add(items)
     htaccess.create_at(share=share,
                        users=users + managing_users,
@@ -101,7 +102,8 @@ def add(share_directory, user_apache_directive="{}", group_apache_directive="{}"
                                                  groups=groups,
                                                  managing_groups=managing_groups,
                                                  managing_users=managing_users,
-                                                 domain=domain)
+                                                 domain=domain,
+                                                 manage_permissions=share.MANAGE_PERMISSION_UNLOCK)
         share.permissions = updated_acl
 
     if lock:
@@ -163,7 +165,7 @@ def ensure_items_exist(items):
             raise FileNotFoundError("Items '%s' does not exist! (%s)" % (os.path.basename(item), item))
 
 
-def generate_permissions(users, groups, managing_users, managing_groups, domain):
+def generate_permissions(users, groups, managing_users, managing_groups, domain, manage_permissions):
     """
     Builds and returns an Access Control List.
     """
@@ -187,14 +189,14 @@ def generate_permissions(users, groups, managing_users, managing_groups, domain)
                                        flags='',
                                        identity=user,
                                        domain=domain,
-                                       permissions='rwxaDdtTNcCo')
+                                       permissions=manage_permissions)
         entries.append(user_ace)
     for group in managing_groups:
         group_ace = AccessControlEntity(entry_type='A',
                                         flags='g',
                                         identity=group,
                                         domain=domain,
-                                        permissions='rwxaDdtTNcCo')
+                                        permissions=manage_permissions)
         entries.append(group_ace)
 
     acl = AccessControlList(entries)

--- a/src/nfs4_share/manage.py
+++ b/src/nfs4_share/manage.py
@@ -51,14 +51,15 @@ def create(share_directory, domain, user_apache_directive="{}", group_apache_dir
                        users=users + managing_users,
                        user_directive_template=user_apache_directive,
                        groups=groups + managing_groups,
-                       group_directive_template=group_apache_directive, )
+                       group_directive_template=group_apache_directive)
     logging.info("Finished creating share at %s" % share.directory)
     if lock:
         share.lock()
     return share
 
 
-def add(share_directory, domain=None, items=None, users=None, groups=None, managing_users=None, managing_groups=None, lock=False, service_application_accounts=None):
+def add(share_directory, user_apache_directive, group_apache_directive, domain=None, items=None, users=None,
+        groups=None, managing_users=None, managing_groups=None, lock=False, service_application_accounts=None):
     """
         Updates a share. The directory representing the share should exist.
             For more information on input variables run nfs4_share add --help
@@ -89,6 +90,11 @@ def add(share_directory, domain=None, items=None, users=None, groups=None, manag
     # Add the users
     if users or groups:
         assert domain, "domain cannot be left empty if trying to add users or groups"
+        htaccess.append_at(share=share,
+                           users=users + managing_users,
+                           user_directive_template=user_apache_directive,
+                           groups=groups + managing_groups,
+                           group_directive_template=group_apache_directive)
         acl = share.permissions
         updated_acl = acl + generate_permissions(users=users + service_application_accounts,
                                                  groups=groups,

--- a/src/nfs4_share/manage.py
+++ b/src/nfs4_share/manage.py
@@ -11,7 +11,8 @@ from .acl import AccessControlList, AccessControlEntity
 
 
 def create(share_directory, domain, user_apache_directive="{}", group_apache_directive="{}",
-           items=None, users=None, groups=None, managing_users=None, managing_groups=None, lock=True, service_application_accounts=None):
+           items=None, users=None, groups=None, managing_users=None, managing_groups=None, lock=True,
+           service_application_accounts=None):
     """
     Creates a share. The directory representing the share should be non-existent.
             For more information on input variables run ./share remove --help

--- a/src/nfs4_share/share.py
+++ b/src/nfs4_share/share.py
@@ -121,8 +121,10 @@ class Share:
         target = self.MANAGE_PERMISSION_LOCK if add_write else self.MANAGE_PERMISSION_UNLOCK
         replacement = self.MANAGE_PERMISSION_UNLOCK if add_write else self.MANAGE_PERMISSION_LOCK
         for entry in self.permissions.entries:
-            if entry.__contains__(target):
-                entry.replace(target, replacement)
+            permission = entry.permissions
+            if permission == target:
+                permission = replacement
+                entry.permissions = permission
             new_entries.append(entry)
         self.permissions = AccessControlList(new_entries)
 

--- a/src/nfs4_share/share.py
+++ b/src/nfs4_share/share.py
@@ -122,7 +122,7 @@ class Share:
         replacement = self.MANAGE_PERMISSION_UNLOCK if add_write else self.MANAGE_PERMISSION_LOCK
         for entry in self.permissions.entries:
             permission = entry.permissions
-            if permission == target:
+            if sorted(list(permission)) == sorted(list(target)):
                 permission = replacement
                 entry.permissions = permission
             new_entries.append(entry)

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -40,13 +40,17 @@ def test_add_file(single_file_share, source_dir):
 def test_add_user(single_file_share, variables):
     from nfs4_share.manage import add
     from nfs4_share import acl
-    extra_user_permissions = acl.AccessControlEntity('A', '', variables["account_someone_else"], variables["domain_name"], 'rxtncy')
+    extra_user_permissions = acl.AccessControlEntity('A', '', variables["account_someone_else"],
+                                                     variables["domain_name"], 'rxtncy')
     before_share_permissions = acl.AccessControlList.from_file(single_file_share.directory)
 
-    add(single_file_share.directory, users=[variables["account_someone_else"]], domain=variables["domain_name"], lock=True)
+    add(single_file_share.directory, users=[variables["account_someone_else"]], domain=variables["domain_name"],
+        lock=True, user_apache_directive=variables["user_directive"],
+        group_apache_directive=variables["group_directive"])
     after_share_permissions = acl.AccessControlList.from_file(single_file_share.directory)
 
-    assert after_share_permissions == before_share_permissions + acl.AccessControlList([extra_user_permissions])
+    assert sorted(after_share_permissions.entries) == sorted(before_share_permissions.entries +
+                                                             acl.AccessControlList([extra_user_permissions]).entries)
 
 
 def test_add_group(single_file_share, variables, extra_group="pmc_research"):
@@ -55,10 +59,12 @@ def test_add_group(single_file_share, variables, extra_group="pmc_research"):
     extra_user_permissions = acl.AccessControlEntity('A', 'g', extra_group, variables["domain_name"], 'rxtncy')
     before_share_permissions = acl.AccessControlList.from_file(single_file_share.directory)
 
-    add(single_file_share.directory, groups=[extra_group], domain=variables["domain_name"], lock=True)
+    add(single_file_share.directory, groups=[extra_group], domain=variables["domain_name"], lock=True,
+        user_apache_directive=variables["user_directive"], group_apache_directive=variables["group_directive"])
     after_share_permissions = acl.AccessControlList.from_file(single_file_share.directory)
 
-    assert after_share_permissions == before_share_permissions + acl.AccessControlList([extra_user_permissions])
+    assert sorted(after_share_permissions.entries) == sorted(before_share_permissions.entries +
+                                                             acl.AccessControlList([extra_user_permissions]).entries)
 
 
 def test_cli_with_file(single_file_share, source_dir, variables):


### PR DESCRIPTION
# What has changed and why?
Added functionality to add new users/groups to the htaccess file while running the script in ADD mode. This is needed as currently the user and group args are ignored in this mode.

# Notes:
The test cases are still working except for the lock check however this seemed to be already be broken when using the master branch